### PR TITLE
Update to val_to_percent function in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,8 +132,5 @@ Rollout.prototype.flags = function () {
 }
 
 Rollout.prototype.val_to_percent = function (text) {
-  var n = crypto.createHash('md5').update(text).digest('hex').replace(letters, function (_, letter) {
-    return alpha.indexOf(letter)
-  })
-  return parseFloat(n.substr(0, 2) + '.' + n.substr(2, 3))
+  return parseInt(crypto.createHash('md5').update(text).digest('hex').substr(0, 5), 16) % 100;
 }


### PR DESCRIPTION
The current val_to_percent function returns percentages that are skewed more towards the lower end of the range because you are using a hex encoding, which assigns more probability to numbers 0-5 that correspond to the hex letters a-f. In practice, when I ran that function 100,000 with random parameters I would get a distribution of 63-37%.  The proposed changes make it a 50-50% distribution.
