### PR TITLE
Generate hash distribution histogram

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+hash-dist/results.txt
+hash-dist/results.png

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: test
+.PHONY: test lint hash-dist
 
 test:
 	./node_modules/.bin/mocha --ui bdd --reporter spec tests
 
 lint:
 	./node_modules/.bin/jshint ./
+
+hash-dist:
+	./hash-dist/run.sh

--- a/hash-dist/generate.js
+++ b/hash-dist/generate.js
@@ -1,0 +1,30 @@
+var rollout = require('../index');
+var subject = rollout();
+
+function randomString(length) {
+  var resultChars = [];
+  var possibleChars = "abcdefghijklmnopqrstuvwxyz0123456789";
+  var randomIndex;
+
+  for (var i = 0; i < length; i++) {
+    randomIndex = Math.floor(Math.random() * possibleChars.length);
+    resultChars.push(possibleChars.charAt(randomIndex));
+  }
+
+  return resultChars.join('');
+}
+
+function randomId() {
+  var randomLength = 10 + Math.floor(Math.random() * 20);
+  return randomString(randomLength);
+}
+
+var n = 100000;
+var sample
+while (n) {
+  sample = subject.val_to_percent(randomId());
+  process.stdout.write(sample + '\n');
+  n--;
+}
+
+process.exit();

--- a/hash-dist/histogram.plt
+++ b/hash-dist/histogram.plt
@@ -1,0 +1,11 @@
+set term png
+set output 'results.png'
+
+set key off
+set border 3
+set style fill solid 1.0 noborder
+
+bin_width=1
+bin(x,width)=width*floor(x/width)
+
+plot 'results.txt' using (bin($1,bin_width)):(1.0) smooth freq with boxes

--- a/hash-dist/run.sh
+++ b/hash-dist/run.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+
+command -v gnuplot >/dev/null 2>&1 || {
+  echo >&2 '`gnuplot` command is not installed.'
+  echo >&2 'Run `brew install gnuplot` and retry.'
+  exit 1
+}
+
+# Ensure the script runs in its working directory
+pushd "$(dirname "$0")"
+
+# Generate random sample results and save to a file
+node generate.js > results.txt
+
+# Create a graph from the random sample data
+gnuplot histogram.plt
+
+# Show the resulting graph in QuickLook on OS X
+qlmanage -p "results.png" >& /dev/null &
+
+popd


### PR DESCRIPTION

![results](https://user-images.githubusercontent.com/11916110/36175915-fc4aad8c-10de-11e8-8add-1d243214bc71.png)

I cooked this up while validating the updated hash function referred to in https://github.com/mix/node-rollout/pull/1 and implemented in https://github.com/mix/node-rollout/commit/c4d887a385329a09a03be4e06c13b62403968e55

There's three components:
  * Javascript to generate `val_to_percentage` samples from random strings
  * gnuplot to draw the histogram from the sample data
  * A bash script to run the Javascript and gnuplot commands

Not sure if it's worthy of being part of this project, but I didn't want to throw it away either.