### PR TITLE
Modifier enhancements to support multiple experiment groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,18 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/1cf0304dee9b1f264a64/maintainability)](https://codeclimate.com/github/mix/node-rollout/maintainability)
 Feature rollout management for Node.js built on Redis
 
+### Example Usage
+
+#### Installation
+
 ``` sh
 npm install node-rollout --save
 ```
 
+#### Basic Configuration
+
 ``` js
-// configuration.js
+// basic_configuration.js
 var client = require('redis').createClient()
 var rollout = require('node-rollout')(client)
 rollout.handler('new_homepage', {
@@ -20,7 +26,7 @@ rollout.handler('new_homepage', {
   employee: {
     percentage: 100,
     condition: function (val) {
-      return val.match(/@company-email\.com$/)
+      return /@company-email\.com$/.test(val)
     }
   },
   // 50% of users in San Francisco
@@ -29,6 +35,16 @@ rollout.handler('new_homepage', {
     condition: function (val) {
       return geolib.getDistance([val.lat, val.lon], [37.768, -122.426], 'miles') < 7
     }
+  },
+  // Asynchronous database lookup
+  admin: {
+    percentage: 100,
+    condition: function (val) {
+      return db.lookupUser(val)
+      .then(function (user) {
+        return user.isAdmin()
+      })
+    }
   }
 })
 
@@ -36,21 +52,22 @@ module.exports = rollout
 ```
 
 ``` js
-// A typical Express app
+// A typical Express app demonstrating rollout flags
 ...
-var rollout = require('./configuration')
+var rollout = require('./basic_configuration')
 
 app.get('/', new_homepage, old_homepage)
 
 function new_home_page(req, res, next) {
   rollout.get('new_homepage', req.current_user.id, {
     employee: req.current_user.email,
-    geo: [req.current_user.lat, req.current_user.lon]
+    geo: [req.current_user.lat, req.current_user.lon],
+    admin: req.current_user.id
   })
-    .then(function () {
-      res.render('home/new-index')
-    })
-    .otherwise(next)
+  .then(function () {
+    res.render('home/new-index')
+  })
+  .catch(next)
 }
 
 function old_home_page (req, res, next) {
@@ -59,6 +76,44 @@ function old_home_page (req, res, next) {
 
 ```
 
+#### Experiment groups
+
+``` js
+// experiment_groups_configuration.js
+var client = require('redis').createClient()
+var rollout = require('node-rollout')(client)
+// An experiment with 3 randomly-assigned groups
+rollout.handler('homepage_variant', {
+  versionA: {
+    percentage: { min: 0, max: 33 }
+  },
+  versionB: {
+    percentage: { min: 33, max: 66 }
+  },
+  versionC: {
+    percentage: { min: 66, max: 100 }
+  }
+})
+
+module.exports = rollout
+```
+
+``` js
+// A typical Express app demonstrating experiment groups
+...
+var rollout = require('./experiment_groups_configuration')
+
+app.get('/', homepage)
+
+function homepage(req, res, next) {
+  rollout.get('homepage_variant', req.current_user.id)
+  .then(function (version) {
+    console.assert(/^version(A|B|C)$/.test(version) === true)
+    res.render('home/' + version)
+  })
+}
+
+```
 
 ### API Options
 
@@ -71,22 +126,22 @@ function old_home_page (req, res, next) {
 
 ``` js
 rollout.get('button_test', 123)
-  .then(function () {
-    render('blue_button')
-  })
-  .otherwise(function () {
-    render('red_button')
-  })
+.then(function () {
+  render('blue_button')
+})
+.catch(function () {
+  render('red_button')
+})
 
 rollout.get('another_feature', 123, {
   employee: 'user@example.org'
 })
-  .then(function () {
-    render('blue_button')
-  })
-  .otherwise(function () {
-    render('red_button')
-  })
+.then(function () {
+  render('blue_button')
+})
+.catch(function () {
+  render('red_button')
+})
 ```
 
 #### `rollout.multi(keys)`
@@ -103,28 +158,30 @@ rollout.multi([
     employees: req.user.email // 'joe@company.com'
   }]
 ])
-  .then(function (results) {
-    results.forEach(function (r) {
-      console.log(i.isFulfilled()) // Or 'isRejected()'
-    })
+.then(function (results) {
+  results.forEach(function (r) {
+    console.log(i.isFulfilled()) // Or 'isRejected()'
   })
+})
 
 rollout.get('another_feature', 123, {
   employee: 'user@example.org'
 })
-  .then(function () {
-    render('blue_button')
-  })
-  .otherwise(function () {
-    render('red_button')
-  })
+.then(function () {
+  render('blue_button')
+})
+.catch(function () {
+  render('red_button')
+})
 ```
 
 #### `rollout.handler(key, flags)`
  - `key`: `String` The rollout feature key
  - `flags`: `Object`
   - `flagname`: `String` The name of the flag. Typically `id`, `employee`, `ip`, or any other arbitrary item you would want to modify the rollout
-    - `percentage`: `NumberRange` from 0 - 100. Can be set to a third decimal place such as `0.001` or `99.999`. Or simply `0` to turn off a feature, or `100` to give a feature to all users
+    - `percentage`:
+      - `Number` from `0` - `100`. Can be set to a third decimal place such as `0.001` or `99.999`. Or simply `0` to turn off a feature, or `100` to give a feature to all users
+      - `Object` containing `min` and `max` keys representing a range of `Number`s between `0` - `100`
     - `condition`: `Function` a white-listing method by which you can add users into a group. See examples.
       - if `condition` returns a `Promise` (*a thenable object*), then it will use the fulfillment of the `Promise` to resolve or reject the `handler`
 
@@ -157,7 +214,10 @@ rollout.handler('admin_section', {
 
 #### `rollout.update(key, flags)`
  - `key`: `String` The rollout feature key
- - `flags`: `Object` mapping of `flagname`:`String` to `percentage`:`Number`
+ - `flags`: `Object` mapping of `flagname`:`String` to `percentage`
+   - `percentage`:
+     - `Number` from `0` - `100`. Can be set to a third decimal place such as `0.001` or `99.999`. Or simply `0` to turn off a feature, or `100` to give a feature to all users
+     - `Object` containing `min` and `max` keys representing a range of `Number`s between `0` - `100`
  - returns `Promise`
 
 ``` js
@@ -176,17 +236,23 @@ rollout.update('new_homepage', {
   - returns `Promise`: resolves with the flags, their names, and values
 
 ``` js
-rollout.mods('new_homepage').then(function (mods) {
-  flags.employee == 100
-  flags.geo_sf == 50.000
-  flags.id == 33.333
+rollout.mods('new_homepage')
+.then(function (mods) {
+  console.assert(mods.employee == 100)
+  console.assert(mods.geo_sf == 50.000)
+  console.assert(mods.id == 33.333)
 })
 ```
 
 #### `rollout.flags()`
+  - return `Promise`: resolves with an array of configured rollout flag names
 
 ``` js
-rollout.flags() == ['new_homepage', 'other_secret_feature']
+rollout.flags()
+.then(function (flags) {
+  console.assert(flags[0] === 'new_homepage')
+  console.assert(flags[1] === 'other_secret_feature')
+})
 ```
 
 ### Tests

--- a/index.js
+++ b/index.js
@@ -102,10 +102,9 @@ Rollout.prototype.get = function (key, id, opt_values, multi) {
           // Treat rejected conditions as inapplicable modifiers
           if (resultPromise.isFulfilled()) {
             resultValue = resultPromise.value()
-            // Treat resolved conditions with non-false values as affirmative
-            // (This is to handle `Promise.resolve()` and `Promise.resolve(null)`)
-            if (resultValue !== false) {
-              return true
+            // Treat resolved conditions with truthy values as affirmative
+            if (resultValue) {
+              return resultPromise.flagModifier
             }
           }
         }

--- a/index.js
+++ b/index.js
@@ -83,9 +83,11 @@ Rollout.prototype.get = function (key, id, opt_values, multi) {
           if (typeof output.then === 'function') {
             // Normalize thenable to Bluebird Promise
             // Reflect the Promise to coalesce rejections
-            deferreds.push(Promise.resolve(output).reflect())
+            output = Promise.resolve(output).reflect()
+            output.flagModifier = modifier
+            deferreds.push(output)
           } else {
-            return true
+            return modifier
           }
         }
       }

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -36,6 +36,23 @@ describe('rollout', function () {
     })).to.be.fulfilled
   })
 
+  it('fulfills with applicable modifier for percentage', function () {
+    subject.handler('secret_feature', {
+      everyone: {
+        percentage: 0
+      },
+      employee: {
+        percentage: 100,
+        condition: isCompanyEmail
+      }
+    })
+    var result = subject.get('secret_feature', 123, {
+      employee: 'me@company.com'
+    })
+    expect(result).to.be.fulfilled
+    expect(result).to.eventually.equal('employee')
+  })
+
   it('fulfills when condition returns a resolved promise', function () {
     subject.handler('promise_secret_feature', {
       beta_testa: {
@@ -177,9 +194,9 @@ describe('rollout', function () {
       ])
       .then(function (result) {
         expect(result[0].isFulfilled()).to.be.true
-        expect(result[0].value()).to.be.true
+        expect(result[0].value()).to.equal('employee')
         expect(result[1].isFulfilled()).to.be.true
-        expect(result[1].value()).to.be.true
+        expect(result[1].value()).to.equal('employee')
         expect(result[2].isRejected()).to.be.true
       })
     })

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -223,15 +223,39 @@ describe('rollout', function () {
       }
     })
     .then(function () {
-      var result = subject.mods('super_secret')
+      var result = subject.modifiers('super_secret')
       return Promise.all([
         expect(result).to.be.fulfilled,
-        expect(result).to.eventually.deep.equal({ foo: '12', bar: '34' })
+        expect(result).to.eventually.deep.equal({
+          foo: 12, 
+          bar: 34
+        })
       ])
     })
   })
 
-  it('can retrieve all flagnames', function () {
+  it('can retrieve range mod values', function () {
+    return subject.handler('super_secret', {
+      foo: {
+        percentage: { min: 0, max: 50 }
+      },
+      bar: {
+        percentage: { min: 50, max: 100 }
+      }
+    })
+    .then(function () {
+      var result = subject.modifiers('super_secret')
+      return Promise.all([
+        expect(result).to.be.fulfilled,
+        expect(result).to.eventually.deep.equal({
+          foo: { min: 0, max: 50 },
+          bar: { min: 50, max: 100 }
+        })
+      ])
+    })
+  })
+
+  it('can retrieve all handler names', function () {
     var o = {
       foo: {
         percentage: 100
@@ -242,7 +266,7 @@ describe('rollout', function () {
       subject.handler('huzzah', o)
     ])
     .then(function () {
-      var result = subject.flags()
+      var result = subject.handlers()
       return Promise.all([
         expect(result).to.be.fulfilled,
         expect(result).to.eventually.deep.equal(['youza', 'huzzah'])

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -53,10 +53,7 @@ describe('rollout', function () {
       var result = subject.get('secret_feature', 123, {
         employee: 'me@company.com'
       })
-      return Promise.all([
-        expect(result).to.be.fulfilled,
-        expect(result).to.eventually.equal('employee')
-      ])
+      return expect(result).to.eventually.equal('employee')
     })
   })
 
@@ -82,10 +79,7 @@ describe('rollout', function () {
     it('fulfills with applicable modifier for range', function () {
       subject.val_to_percent.onCall(0).returns(37)
       var result = subject.get('secret_feature', 123)
-      return Promise.all([
-        expect(result).to.be.fulfilled,
-        expect(result).to.eventually.equal('groupB')
-      ])
+      return expect(result).to.eventually.equal('groupB')
     })
 
     it('fulfills multiple with applicable modifiers for ranges', function () {
@@ -224,13 +218,10 @@ describe('rollout', function () {
     })
     .then(function () {
       var result = subject.modifiers('super_secret')
-      return Promise.all([
-        expect(result).to.be.fulfilled,
-        expect(result).to.eventually.deep.equal({
-          foo: 12, 
-          bar: 34
-        })
-      ])
+      return expect(result).to.eventually.deep.equal({
+        foo: 12,
+        bar: 34
+      })
     })
   })
 
@@ -245,13 +236,10 @@ describe('rollout', function () {
     })
     .then(function () {
       var result = subject.modifiers('super_secret')
-      return Promise.all([
-        expect(result).to.be.fulfilled,
-        expect(result).to.eventually.deep.equal({
-          foo: { min: 0, max: 50 },
-          bar: { min: 50, max: 100 }
-        })
-      ])
+      return expect(result).to.eventually.deep.equal({
+        foo: { min: 0, max: 50 },
+        bar: { min: 50, max: 100 }
+      })
     })
   })
 
@@ -267,10 +255,7 @@ describe('rollout', function () {
     ])
     .then(function () {
       var result = subject.handlers()
-      return Promise.all([
-        expect(result).to.be.fulfilled,
-        expect(result).to.eventually.deep.equal(['youza', 'huzzah'])
-      ])
+      return expect(result).to.eventually.deep.equal(['youza', 'huzzah'])
     })
   })
 
@@ -352,10 +337,7 @@ describe('rollout', function () {
       })
       .then(function() {
         var result = subject.get('experiment', 123)
-        return Promise.all([
-          expect(result).to.be.fulfilled,
-          expect(result).to.eventually.equal('groupA')
-        ])
+        return expect(result).to.eventually.equal('groupA')
       })
       .then(function () {
         return subject.update('experiment', {
@@ -364,10 +346,7 @@ describe('rollout', function () {
         })
         .then(function () {
           var result = subject.get('experiment', 123)
-          return Promise.all([
-            expect(result).to.be.fulfilled,
-            expect(result).to.eventually.equal('groupB')
-          ])
+          return expect(result).to.eventually.equal('groupB')
         })
       })
     })
@@ -390,7 +369,7 @@ describe('rollout', function () {
           employee: 'regular@gmail.com'
         })
         // is rejected by company email, but falls within allowed regular users
-        return expect(result).to.be.fulfilled
+        return expect(result).to.eventually.equal('id')
       })
     })
   })


### PR DESCRIPTION
  * Use the applicable modifier as the rollout flag value (instead of `true`).
  * Allow modifier percentages to be specified as a `{min: 0, max: 100}` range.

Combined, these features allow rollouts to be used as a means of doing A/B/C/... tests with support for an absurd number of experiment groups. The practical limitation would be the number of distinct IEEE754 double-precision 64-bit floating point values between Javascript `Number.MIN_VALUE` (`5e-324`) and `100`, although in practice this would be unwieldy and inadvisable.

The new rollout flag value format constitutes an API change and is not backwards-compatible; this should be considered a major version breaking change.

The modifier percentages is completely backwards-compatible and is opt-in through configuration.

This branch is based on #6 and #7 and also implements some readability improvements.