### PR TITLE
Revert `get` result value type API breakage

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ Rollout.prototype.get = function (key, id, opt_values, multi) {
             // Treat resolved conditions with non-false values as affirmative
             // (This is to handle `Promise.resolve()` and `Promise.resolve(null)`)
             if (resultValue !== false) {
-              return resultPromise.flagModifier
+              return true
             }
           }
         }


### PR DESCRIPTION
Breaking changes from #9 accidentally snuck into #6 

This PR reverts the API breakage so that the `0.4.x` releases have one final patch where everything works.