### PR TITLE
Log warning when rollout modifier condition throws

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,13 @@ Rollout.prototype.get = function (key, id, opt_values, multi) {
         if (!modifiers[modName].condition) {
           modifiers[modName].condition = defaultCondition
         }
-        output = modifiers[modName].condition(opt_values[modName])
+        try {
+          output = modifiers[modName].condition(opt_values[modName])
+        }
+        catch (err) {
+          console.warn('rollout key[' + key + '] mod[' + modName + '] condition threw:', err)
+          continue
+        }
         if (output) {
           if (typeof output.then === 'function') {
             // Normalize thenable to Bluebird Promise

--- a/index.js
+++ b/index.js
@@ -83,8 +83,7 @@ Rollout.prototype.get = function (key, id, opt_values, multi) {
         }
         try {
           output = modifiers[modName].condition(opt_values[modName])
-        }
-        catch (err) {
+        } catch (err) {
           console.warn('rollout key[' + key + '] mod[' + modName + '] condition threw:', err)
           continue
         }


### PR DESCRIPTION
Quick Follow-up to https://github.com/mix/mix/pull/3236

In practice, errors thrown from `Rollout.prototype.get` get swallowed and ignored because rejection typically means "does not apply". Changing this would require modifying the behavior of consumers, and is not in scope for this quick fix.

Conditions that throw errors are still treated as rejected, but at least you'll see it in the logs now.

An alternative, but more-involved solution would be to create a custom error type like `RolloutNotInclusiveError` so that callers can differentiate between "normal" errors and "abnormal" errors.